### PR TITLE
Allows mbed_ntp_client interface target to be exported

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,17 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 
 project(mbed_ntp_client)
 
-FILE(GLOB_RECURSE ${PROJECT_NAME}_SOURCES "src/*.c*")
-FILE(GLOB_RECURSE ${PROJECT_NAME}_INCLUDES "include/*.h*")
+find_package(bir_cmake_modules)
 
-install(DIRECTORY include
-    DESTINATION src/${PROJECT_NAME}
-    FILES_MATCHING PATTERN "*.h*"
-    PATTERN "*~" EXCLUDE
-)
-    
-install(DIRECTORY src
-    DESTINATION src/${PROJECT_NAME}
-    FILES_MATCHING PATTERN "*.c*"
-    PATTERN "*~" EXCLUDE
-)
+# Macro defined in bir_cmake_modules
+bir_export_interface_library()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 
 project(mbed_ntp_client)
 

--- a/README.md
+++ b/README.md
@@ -4,22 +4,37 @@ This library allows you to fetch time information from a NTP server.
 
 For an example application, please see https://github.com/ARMmbed/ntp-client-example.
 
-## Getting started
+## Usage
+> **Note:** This library is not intended to be compiled by itself. Therefore, the consumer application must link to it.
 
-If you don't have an existing Mbed OS project, go ahead and create one.
+To use the library with Mbed OS 6 just add the command below in the application's `CMakeLists.txt` file
 
-```sh
-mbed new ntp-project
-cd ntp-project
+```cmake
+find_package(mbed_ntp_client REQUIRED CONFIG)
 ```
 
-Now add the library to your project.
+and then link with your application, for example
 
-```sh
-mbed import https://github.com/ARMmbed/ntp-client
+```cmake
+[...]
+
+  add_executable(${APP_TARGET}
+    src/main.cpp
+  )
+
+  target_include_directories(${APP_TARGET}
+    PRIVATE  
+      include
+  )
+
+  target_link_libraries(${APP_TARGET}
+    PRIVATE
+      mbed-os
+      mbed_ntp_client::mbed_ntp_client
+  )
+
+[...]
 ```
-
-The library will now be available in your project. Please see the API documentation below for usage information.
 
 ## API
 

--- a/cmake/mbed_ntp_client-config.cmake.in
+++ b/cmake/mbed_ntp_client-config.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")
+check_required_components("@PROJECT_NAME@")

--- a/manifest.xml
+++ b/manifest.xml
@@ -7,4 +7,5 @@
     <depend package="cmake"/>
     <depend package="bir_cmake_modules"/>
     <depend package="ntp" />
+    <depend package="mbed"/>
 </package>

--- a/manifest.xml
+++ b/manifest.xml
@@ -4,5 +4,7 @@
     <maintainer>ARMmbed</maintainer>
     <license>Apache-2.0</license>
     <url>https://github.com/ARMmbed/ntp-client</url>
-</package>
 
+    <depend package="bir_cmake_modules"/>
+    <depend package="ntp" />
+</package>

--- a/manifest.xml
+++ b/manifest.xml
@@ -4,7 +4,7 @@
     <maintainer>ARMmbed</maintainer>
     <license>Apache-2.0</license>
     <url>https://github.com/ARMmbed/ntp-client</url>
-
+    <depend package="cmake"/>
     <depend package="bir_cmake_modules"/>
     <depend package="ntp" />
 </package>


### PR DESCRIPTION
- #### Overview
  - Allows mbed_ntp_client interface target to be exported to be cross-compiled or used in other downstream CMake files by running `find_package` command
- #### Use the following settings in the overrides file for docker testing
  -  _overrides.yaml_
  ```yaml
  - mbed_ntp_client:
    branch: upgrade-build-system

  - bir_cmake_modules:
    branch: change-pmb-firmware-build-tool
  ```
  -  _manifest_
  ```yaml
  package_sets:
     - github: Brazilian-Institute-of-Robotics/bir.ros-package_set
       private: true
     - github: Brazilian-Institute-of-Robotics/bir.mccr-package_set
       private: true
  
  layout:
    - mbed_ntp_client
  ```
- #### Depends On:
  - [x] https://github.com/Brazilian-Institute-of-Robotics/bir_cmake_modules/pull/17